### PR TITLE
fix derek's id

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,4 +1,4 @@
 - Steve Lasker <steve.lasker@microsoft.com> (@stevelasker)
-- Derek McGowan <derek.mcgowan@docker.com> (@derekmcgowan)
+- Derek McGowan <derek.mcgowan@docker.com> (@dmcgowan)
 - Mike Brown <brownwm@us.ibm.com> (@mikebrow)
 - Stephen Day <stevvooe@gmail.com> (@stevvooe)


### PR DESCRIPTION
Just a quick edit of the maintainer's list to correct Derek's github id.

Signed-off-by: Mike Brown <brownwm@us.ibm.com>