### PR TITLE
Add Go spec for Artifacts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/opencontainers/artifacts
+
+go 1.16
+
+require github.com/opencontainers/go-digest v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
+github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=

--- a/specs-go/v2/artifact.go
+++ b/specs-go/v2/artifact.go
@@ -1,0 +1,27 @@
+package v2
+
+import "github.com/opencontainers/artifacts/specs-go"
+
+// Artifact describes a registry artifact.
+// This structure provides `application/vnd.oci.artifact.manifest.v1+json` mediatype when marshalled to JSON.
+type Artifact struct {
+	specs.Versioned
+
+	// MediaType is the media type of the object this schema refers to.
+	MediaType string `json:"mediaType"`
+
+	// ArtifactType is the artifact type of the object this schema refers to.
+	ArtifactType string `json:"artifactType"`
+
+	// Config references the configuration of the object this schema refers to. It is optional.
+	Config *Descriptor `json:"config,omitempty"`
+
+	// Blobs is a collection of blobs referenced by this manifest.
+	Blobs []Descriptor `json:"blobs"`
+
+	// Manifests is a collection of manifests this artifact is linked to.
+	Manifests []Descriptor `json:"manifests"`
+
+	// Annotations contains arbitrary metadata for the artifact manifest.
+	Annotations map[string]string `json:"annotations,omitempty"`
+}

--- a/specs-go/v2/artifacttype.go
+++ b/specs-go/v2/artifacttype.go
@@ -1,0 +1,6 @@
+package v2
+
+const (
+	// ArtifactTypeNotaryV2 specifies the artifact type for a notary V2 object.
+	ArtifactTypeNotaryV2 = "application/vnd.cncf.notary.v2"
+)

--- a/specs-go/v2/artifacttype.go
+++ b/specs-go/v2/artifacttype.go
@@ -1,6 +1,0 @@
-package v2
-
-const (
-	// ArtifactTypeNotaryV2 specifies the artifact type for a notary V2 object.
-	ArtifactTypeNotaryV2 = "application/vnd.cncf.notary.v2"
-)

--- a/specs-go/v2/descriptor.go
+++ b/specs-go/v2/descriptor.go
@@ -1,0 +1,64 @@
+// Copyright 2016 The Linux Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2
+
+import digest "github.com/opencontainers/go-digest"
+
+// Descriptor describes the disposition of targeted content.
+// This structure provides `application/vnd.oci.descriptor.v1+json` mediatype
+// when marshalled to JSON.
+type Descriptor struct {
+	// MediaType is the media type of the object this schema refers to.
+	MediaType string `json:"mediaType,omitempty"`
+
+	// Digest is the digest of the targeted content.
+	Digest digest.Digest `json:"digest"`
+
+	// Size specifies the size in bytes of the blob.
+	Size int64 `json:"size"`
+
+	// URLs specifies a list of URLs from which this object MAY be downloaded
+	URLs []string `json:"urls,omitempty"`
+
+	// Annotations contains arbitrary metadata relating to the targeted content.
+	Annotations map[string]string `json:"annotations,omitempty"`
+
+	// Platform describes the platform which the image in the manifest runs on.
+	//
+	// This should only be used when referring to a manifest.
+	Platform *Platform `json:"platform,omitempty"`
+}
+
+// Platform describes the platform which the image in the manifest runs on.
+type Platform struct {
+	// Architecture field specifies the CPU architecture, for example
+	// `amd64` or `ppc64`.
+	Architecture string `json:"architecture"`
+
+	// OS specifies the operating system, for example `linux` or `windows`.
+	OS string `json:"os"`
+
+	// OSVersion is an optional field specifying the operating system
+	// version, for example on Windows `10.0.14393.1066`.
+	OSVersion string `json:"os.version,omitempty"`
+
+	// OSFeatures is an optional field specifying an array of strings,
+	// each listing a required OS feature (for example on Windows `win32k`).
+	OSFeatures []string `json:"os.features,omitempty"`
+
+	// Variant is an optional field specifying a variant of the CPU, for
+	// example `v7` to specify ARMv7 when architecture is `arm`.
+	Variant string `json:"variant,omitempty"`
+}

--- a/specs-go/v2/mediatype.go
+++ b/specs-go/v2/mediatype.go
@@ -1,0 +1,6 @@
+package v2
+
+const (
+	// MediaTypeArtifactManifest specifies the media type for an OCI artifact.
+	MediaTypeArtifactManifest = "application/vnd.oci.artifact.manifest.v1+json"
+)

--- a/specs-go/versioned.go
+++ b/specs-go/versioned.go
@@ -1,0 +1,9 @@
+package specs
+
+// Versioned provides a struct with the manifest schemaVersion and mediaType.
+// Incoming content with unknown schema version can be decoded against this
+// struct to check the version.
+type Versioned struct {
+	// SchemaVersion is the image manifest schema that this image follows
+	SchemaVersion int `json:"schemaVersion"`
+}


### PR DESCRIPTION
This PR adds a new Go type, `Artifact`, that describes an OCI Artifact manifest. 
Spec available here: opencontainers#29