### PR TITLE
Update Amazon ECR name to official name

### DIFF
--- a/implementors.md
+++ b/implementors.md
@@ -2,7 +2,7 @@
 
 Registries currently supporting OCI Artifacts
 
-- [Amazon Container Registry](https://aws.amazon.com/blogs/containers/oci-artifact-support-in-amazon-ecr/)
+- [Amazon ECR](https://aws.amazon.com/blogs/containers/oci-artifact-support-in-amazon-ecr/)
 - [Azure Container Registry](https://aka.ms/acr/artifacts)
 - [CNCF Distribution](https://github.com/distribution/distribution/) 
 - [Project Harbor](https://goharbor.io/blog/harbor-2.0/)


### PR DESCRIPTION
Small nit, but ECR is typically referred to as "Amazon Elastic Container Registry" or "Amazon ECR". Thanks!