### PR TITLE
Clarify ORAS is not an OCI project

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ The current state of the [OCI Artifacts][oci-artifacts] repository:
 - The repository contains guidance for using [v1.0.1][oci-image-v101] of the [OCI image manifest][image-manifest] representing *individual* non-container image artifact types.
 - This project recognizes that additional work is needed to find ways to improve existing OCI artifact types, such as OCI images, to formally include a software bill of materials (SBOMs), scan results, signatures, and other OCI artifact related extensions. Depending on the implementation chosen, additional APIs to manage these extensions may also be needed. We believe these requirements will either require modifications to the existing specs or some new specification depending on the output of various working groups.  
   This project, however, does not currently have the mission to create new specifications or commit changes to the existing specifications.
-- External to OCI there exists an active community of developers working under the [oras-project/artifacts-spec repository][oras-artifacts] on proposed changes to the OCI specifications.
 - An [OCI working group for reference types][oci-reftype-wg] has been proposed to work out how OCI should adopt these extensions.
+- There also exists [oras-project/artifacts-spec repository][oras-artifacts] that is not part of OCI or the above working group.
 
 ## Project Governance and License
 


### PR DESCRIPTION
Based on discussions in [ORAS/artifacts-spec #96](https://github.com/oras-project/artifacts-spec/issues/96) and [ORAS/artifacts-spec #88](https://github.com/oras-project/artifacts-spec/issues/88), I think the wording in the readme gives the false impression that ORAS/artifact-spec is being used as a staging ground for future changes to this or other OCI specs. This clarifies they are their own project developing their own spec separate from the working group.

Signed-off-by: Brandon Mitchell <git@bmitch.net>